### PR TITLE
Save Device Information in Internal Storage

### DIFF
--- a/TenDen/app/src/main/java/com/teamMJW/tenden/AddDevice.java
+++ b/TenDen/app/src/main/java/com/teamMJW/tenden/AddDevice.java
@@ -1,20 +1,28 @@
 package com.teamMJW.tenden;
 
 import android.content.Context;
+import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.view.View;
 import android.widget.Button;
+import android.widget.EditText;
 import android.widget.Switch;
 import android.widget.TextView;
 
 import com.google.gson.Gson;
 
 import java.net.InetAddress;
+import java.net.UnknownHostException;
 
 public class AddDevice extends AppCompatActivity {
 
+    TextView deviceid;
+    TextView devicePower;
+    TextView deviceBrightness;
+    TextView deviceColorTemp;
+    TextView deviceIp;
     private boolean emulatorMode = true;
 
     @Override
@@ -24,17 +32,48 @@ public class AddDevice extends AppCompatActivity {
 
         setDeviceInformation();
 
+        addDevice();
     }
 
-    public void setDeviceInformation() {
+    //Confirm Button
+    private void addDevice() {
+        //create Button object and associate the Confirm button with it
+        Button settingButton = findViewById(R.id.addDeviceButton);
+        //if the button is clicked, then add Device and go to Main page
+        settingButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                EditText editname = findViewById(R.id.deviceName);
+                String editnameText = editname.getText().toString();
+                SharedPreferences s = getSharedPreferences("APPDATA", Context.MODE_PRIVATE);
+                Gson gson = new Gson();
+
+                String json = s.getString("Bulb", null);
+                Device bulb = gson.fromJson(json, Device.class);
+
+                Device myBulb = new Device(editnameText, deviceid.getText().toString(), devicePower.getText().toString(), deviceBrightness.getText().toString(),
+                        deviceColorTemp.getText().toString(), bulb.getCurrentIP());
+                SharedPreferences p = getSharedPreferences("NEWDATA", Context.MODE_PRIVATE);
+                SharedPreferences.Editor editor = p.edit();
+                Gson gsonTo = new Gson();
+                String jsonTo = gsonTo.toJson(myBulb);
+                editor.putString("Bulb", jsonTo);
+                editor.apply();
+
+                System.out.println("----------------------------" + p.getAll());
+                startActivity(new Intent(AddDevice.this, MainActivity.class));
+            }
+        });
+    }
+
+    private void setDeviceInformation() {
 
         if(emulatorMode) {
-
-            TextView deviceid = findViewById(R.id.device_id);
-            TextView devicePower = findViewById(R.id.device_power);
-            TextView deviceBrightness = findViewById(R.id.device_brightness);
-            TextView deviceColorTemp = findViewById(R.id.device_colortemp);
-            TextView deviceIp = findViewById(R.id.device_ip);
+            deviceid = findViewById(R.id.device_id);
+            devicePower = findViewById(R.id.device_power);
+            deviceBrightness = findViewById(R.id.device_brightness);
+            deviceColorTemp = findViewById(R.id.device_colortemp);
+            deviceIp = findViewById(R.id.device_ip);
 
             deviceid.setText("Device ID: ?");
 
@@ -59,11 +98,11 @@ public class AddDevice extends AppCompatActivity {
             String ct = bulb.getCurrentCT();
             InetAddress ip = bulb.getCurrentIP();
 
-            TextView deviceid = findViewById(R.id.device_id);
-            TextView devicePower = findViewById(R.id.device_power);
-            TextView deviceBrightness = findViewById(R.id.device_brightness);
-            TextView deviceColorTemp = findViewById(R.id.device_colortemp);
-            TextView deviceIp = findViewById(R.id.device_ip);
+            deviceid = findViewById(R.id.device_id);
+            devicePower = findViewById(R.id.device_power);
+            deviceBrightness = findViewById(R.id.device_brightness);
+            deviceColorTemp = findViewById(R.id.device_colortemp);
+            deviceIp = findViewById(R.id.device_ip);
 
             if (id == null) {
                 deviceid.setText("Device ID: ?");

--- a/TenDen/app/src/main/java/com/teamMJW/tenden/AppStartSetup.java
+++ b/TenDen/app/src/main/java/com/teamMJW/tenden/AppStartSetup.java
@@ -45,7 +45,9 @@ public class AppStartSetup implements Runnable {
 
         if(emulatorMode) {
 
-            Device myBulb = new Device(bulbId, currentPowerStatus, currentBrightness, currentColorTemperature, finalIpAddress);
+
+        } else {
+            Device myBulb = new Device("", bulbId, currentPowerStatus, currentBrightness, currentColorTemperature, finalIpAddress);
 
             SharedPreferences p = context.getSharedPreferences("APPDATA", Context.MODE_PRIVATE);
             SharedPreferences.Editor editor = p.edit();
@@ -55,7 +57,6 @@ public class AppStartSetup implements Runnable {
             editor.apply();
 
             System.out.println("----------------------------" + p.getAll());
-
         }
 
     }

--- a/TenDen/app/src/main/java/com/teamMJW/tenden/Device.java
+++ b/TenDen/app/src/main/java/com/teamMJW/tenden/Device.java
@@ -3,19 +3,23 @@ package com.teamMJW.tenden;
 import java.net.InetAddress;
 
 public class Device {
+    private String name;
     private String bulbId;
     private String currentPowerStatus;
     private String currentBrightness;
     private String currentCT;
     private InetAddress currentIP;
 
-    public Device(String bulbId, String currentPowerStatus, String currentBrightness, String currentCT, InetAddress currentIP) {
+    public Device(String name, String bulbId, String currentPowerStatus, String currentBrightness, String currentCT, InetAddress currentIP) {
+        this.name = name;
         this.bulbId = bulbId;
         this.currentPowerStatus = currentPowerStatus;
         this.currentBrightness = currentBrightness;
         this.currentCT = currentCT;
         this.currentIP = currentIP;
     }
+
+    public String getName() { return name; };
 
     public String getCurrentPowerStatus() {
         return currentPowerStatus;

--- a/TenDen/app/src/main/java/com/teamMJW/tenden/DeviceSettings.java
+++ b/TenDen/app/src/main/java/com/teamMJW/tenden/DeviceSettings.java
@@ -1,10 +1,13 @@
 package com.teamMJW.tenden;
 
 import android.app.AlertDialog;
+import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.content.res.Resources;
 import android.os.Bundle;
+import android.preference.PreferenceManager;
 import android.support.design.widget.NavigationView;
 import android.support.v4.view.GravityCompat;
 import android.support.v4.widget.DrawerLayout;
@@ -20,12 +23,17 @@ import android.widget.TextView;
 import android.widget.Toast;
 import android.app.AlertDialog;
 
+import com.google.gson.Gson;
+
 import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
 
 public class DeviceSettings extends AppCompatActivity
         implements NavigationView.OnNavigationItemSelectedListener {
 
     protected DrawerLayout drawer;
+    protected boolean emulatorMode = true;
     //
     TextView txt_help_gest;
     TextView txt_help_gest2;
@@ -174,8 +182,39 @@ public class DeviceSettings extends AppCompatActivity
 
     //Display the Device List popup
     private void displayDeviceList() {
-        //temporary strings in the device list
-        String[] devices = {"Device #1", "Device #2", "Device #3"};
+        String devices[] = {"Device #1", "Device #2"};
+
+        if(emulatorMode) {
+            //temporary strings in the device list
+            List<String> deviceArrayList = new ArrayList<String>();
+            deviceArrayList.add("Device #1");
+            deviceArrayList.add("Device #2");
+            devices = deviceArrayList.toArray(new String[0]);
+        } else {
+            SharedPreferences s = getSharedPreferences("NEWDATA", Context.MODE_PRIVATE);
+            Gson gson = new Gson();
+
+            String json = s.getString("Bulb", null);
+            Device bulb = gson.fromJson(json, Device.class);
+
+            if(bulb == null) {
+                String id = "No Devices";
+
+                //temporary strings in the device list
+                List<String> deviceArrayList = new ArrayList<String>();
+                deviceArrayList.add(id);
+                devices = deviceArrayList.toArray(new String[0]);
+
+            } else {
+                String id = bulb.getName();
+
+                //temporary strings in the device list
+                List<String> deviceArrayList = new ArrayList<String>();
+                deviceArrayList.add(id);
+                devices = deviceArrayList.toArray(new String[0]);
+
+            }
+        }
 
         //create an alert dialog for device list
         AlertDialog.Builder builder = new AlertDialog.Builder(this);

--- a/TenDen/app/src/main/java/com/teamMJW/tenden/MainActivity.java
+++ b/TenDen/app/src/main/java/com/teamMJW/tenden/MainActivity.java
@@ -87,6 +87,7 @@ public class MainActivity extends AppCompatActivity
         } else if (id == R.id.color_scheme) {
             Toast.makeText(this, "Color Scheme", Toast.LENGTH_SHORT).show();
         } else if (id == R.id.current_devices) {
+            System.out.println("************************");
             displayDeviceList();
         }
 
@@ -189,13 +190,38 @@ public class MainActivity extends AppCompatActivity
 
     //Display the Device List popup
     private void displayDeviceList() {
-        SharedPreferences s = PreferenceManager.getDefaultSharedPreferences(this);
-        String id = s.getString("id", null);
+        String devices[] = {"Device #1", "Device #2"};
+        if(emulatorMode) {
+            //temporary strings in the device list
+            List<String> deviceArrayList = new ArrayList<String>();
+            deviceArrayList.add("Device #1");
+            deviceArrayList.add("Device #2");
+            devices = deviceArrayList.toArray(new String[0]);
+        } else {
+            SharedPreferences s = getSharedPreferences("NEWDATA", Context.MODE_PRIVATE);
+            Gson gson = new Gson();
 
-        //temporary strings in the device list
-        List<String> deviceArrayList = new ArrayList<String>();
-        deviceArrayList.add(id);
-        String[] devices = deviceArrayList.toArray(new String[0]);
+            String json = s.getString("Bulb", null);
+            Device bulb = gson.fromJson(json, Device.class);
+
+            if(bulb == null) {
+                String id = "No Devices";
+
+                //temporary strings in the device list
+                List<String> deviceArrayList = new ArrayList<String>();
+                deviceArrayList.add(id);
+                devices = deviceArrayList.toArray(new String[0]);
+
+            } else {
+                String id = bulb.getName();
+
+                //temporary strings in the device list
+                List<String> deviceArrayList = new ArrayList<String>();
+                deviceArrayList.add(id);
+                devices = deviceArrayList.toArray(new String[0]);
+
+            }
+        }
 
 
         //create an alert dialog for device list
@@ -238,9 +264,7 @@ public class MainActivity extends AppCompatActivity
 
             powerButton.setChecked(false);
             deviceName.setText("Device Name");
-
         } else {
-
             //get device id and power status data from SharedPreferences (stores primitive data)
             SharedPreferences s = getSharedPreferences("APPDATA", Context.MODE_PRIVATE);
             Gson gson = new Gson();
@@ -272,7 +296,12 @@ public class MainActivity extends AppCompatActivity
             if (id == null) {
                 deviceName.setText("Device Name");
             } else {
-                deviceName.setText(id);
+                //get device id and power status data from SharedPreferences (stores primitive data)
+                SharedPreferences sp = getSharedPreferences("NEWDATA", Context.MODE_PRIVATE);
+                Gson gson_name = new Gson();
+                String json_name = sp.getString("Bulb", null);
+                Device bulb_name = gson_name.fromJson(json_name, Device.class);
+                deviceName.setText(bulb_name.getName());
                 deviceName.setTextSize(20);
             }
         }

--- a/TenDen/app/src/main/res/layout/activity_add_device.xml
+++ b/TenDen/app/src/main/res/layout/activity_add_device.xml
@@ -75,7 +75,7 @@
         app:layout_constraintStart_toStartOf="parent" />
 
     <Button
-        android:id="@+id/button"
+        android:id="@+id/addDeviceButton"
         android:layout_width="89dp"
         android:layout_height="45dp"
         android:layout_marginStart="8dp"
@@ -166,7 +166,7 @@
     </ScrollView>
 
     <EditText
-        android:id="@+id/editText"
+        android:id="@+id/deviceName"
         android:layout_width="204dp"
         android:layout_height="43dp"
         android:layout_marginStart="32dp"
@@ -177,8 +177,8 @@
         android:layout_marginBottom="8dp"
         android:background="@color/white"
         android:ems="10"
+        android:hint="Enter Device Name"
         android:inputType="textPersonName"
-        android:text="Enter Device Name"
         android:textSize="15sp"
         android:typeface="sans"
         android:visibility="visible"


### PR DESCRIPTION
- Allow the user to add a prefered name for an device (which will show up in the main page and device popup list)
- Currently have two storages (NEWDATA, which are for new devices, and APPDATA, which are for devices that are found near by) -> Internal storage names probably need to be changed to avoid confusion
- In the Device popup list, show only registered devices
- Need a way to switch between devices